### PR TITLE
Use DOMContentLoaded to detect faster?

### DIFF
--- a/fuckadblock.js
+++ b/fuckadblock.js
@@ -39,8 +39,8 @@
 				}
 			}, 1);
 		};
-		if(window.addEventListener !== undefined) {
-			window.addEventListener('load', eventCallback, false);
+		if(document.addEventListener !== undefined) {
+			document.addEventListener('DOMContentLoaded', eventCallback, false);
 		} else {
 			window.attachEvent('onload', eventCallback);
 		}


### PR DESCRIPTION
Are there any reasons we couldn't use `DOMContentLoaded` to try to detect ad block faster at page load?