### PR TITLE
Wait until page is ready before trying to check

### DIFF
--- a/fuckadblock.js
+++ b/fuckadblock.js
@@ -38,7 +38,7 @@
 					}, 1);
 				}
 			}, 1);
-      self._ready = true;
+			self._ready = true;
 		};
 		if(window.addEventListener !== undefined) {
 			window.addEventListener('load', eventCallback, false);
@@ -82,9 +82,9 @@
 	};
 	
 	FuckAdBlock.prototype.check = function(loop) {
-    if (!this._ready) {
-      return false;
-    }
+		if (!this._ready) {
+			return false;
+		}
 
 		if(loop === undefined) {
 			loop = true;

--- a/fuckadblock.js
+++ b/fuckadblock.js
@@ -38,6 +38,7 @@
 					}, 1);
 				}
 			}, 1);
+      self._ready = true;
 		};
 		if(window.addEventListener !== undefined) {
 			window.addEventListener('load', eventCallback, false);
@@ -81,6 +82,10 @@
 	};
 	
 	FuckAdBlock.prototype.check = function(loop) {
+    if (!this._ready) {
+      return false;
+    }
+
 		if(loop === undefined) {
 			loop = true;
 		}


### PR DESCRIPTION
What are your thoughts on preventing pre-mature calls to `check()`? This would prevent false positives as reported in #22.