### PR TITLE
Ignore test.html file in language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test.html linguist-vendored


### PR DESCRIPTION
Currently your project is detected as an HTML project because of `test.html`. This will make GitHub ignore `test.html` when it computes language statistics. So after this, your project should be recognized as a JavaScript project (and maybe come up in the Trending projects ;).

More information on [Linguist Overrides](https://github.com/github/linguist#overrides) at [github/linguist](https://github.com/github/linguist).