### PR TITLE
Handle getComputedStyle returning null

### DIFF
--- a/fuckadblock.js
+++ b/fuckadblock.js
@@ -155,8 +155,8 @@
 		}
 		if(window.getComputedStyle !== undefined) {
 			var baitTemp = window.getComputedStyle(this._var.bait, null);
-			if(baitTemp.getPropertyValue('display') == 'none'
-			|| baitTemp.getPropertyValue('visibility') == 'hidden') {
+			if(baitTemp && (baitTemp.getPropertyValue('display') == 'none'
+			|| baitTemp.getPropertyValue('visibility') == 'hidden')) {
 				detected = true;
 			}
 		}


### PR DESCRIPTION
If an iframe is display:none in Firefox, window.getComputedStyle returns null.   How about this fix?