### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Node.js/io.js:
 ```
 npm install fuckadblock
 ```
+CDN:
+```
+<script src="https://cdn.jsdelivr.net/npm/fuckadblock@3/fuckadblock.min.js"></script>
+```
 
 
 Code example


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/fuckadblock) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage. 